### PR TITLE
Avoid unnecessary error in windows when using `NODE_ENV`

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,9 +14,9 @@
     "check": "npm run compile && npm run lint && npm run test",
     "clean": "rimraf dist coverage",
     "prebuild": "npm run format && npm run check && npm run clean",
-    "build:umd": "NODE_ENV=umd rollup --config",
-    "build:cjs": "NODE_ENV=cjs rollup --config",
-    "build:es": "NODE_ENV=es rollup --config",
+    "build:umd": "cross-env NODE_ENV=umd rollup --config",
+    "build:cjs": "cross-env NODE_ENV=cjs rollup --config",
+    "build:es": "cross-env NODE_ENV=es rollup --config",
     "build": "npm run build:umd && npm run build:cjs && npm run build:es"
   },
   "author": "Matheus Lima <matheusml90@gmail.com>",
@@ -46,6 +46,7 @@
   },
   "devDependencies": {
     "@types/react": "^16.0.9",
+    "cross-env": "^5.0.5",
     "enzyme": "3.1.0",
     "enzyme-adapter-react-16": "1.0.1",
     "jest": "^21.2.1",
@@ -56,6 +57,7 @@
     "rimraf": "^2.6.2",
     "rollup": "0.50.0",
     "rollup-plugin-commonjs": "8.2.1",
+    "rollup-plugin-filesize": "^1.4.2",
     "rollup-plugin-node-resolve": "3.0.0",
     "rollup-plugin-peer-deps-external": "1.0.0",
     "rollup-plugin-typescript2": "0.7.0",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -2,6 +2,7 @@ import typescript from 'rollup-plugin-typescript2';
 import resolve from 'rollup-plugin-node-resolve';
 import commonjs from 'rollup-plugin-commonjs';
 import uglify from 'rollup-plugin-uglify';
+import filesize from 'rollup-plugin-filesize';
 import peerDeps from 'rollup-plugin-peer-deps-external';
 
 const format = process.env.NODE_ENV;
@@ -28,6 +29,6 @@ const config = {
   ],
 };
 
-isUmd && config.plugins.push(uglify());
+isUmd && config.plugins.push(uglify(), filesize());
 
 export default config;


### PR DESCRIPTION
1. use `cross-env` to avoid unnecessary error in windows when using `NODE_ENV`

2. use `rollup-plugin-size` when building the production files to have a better access of your file size