### PR TITLE
Add deleteCount arg to 1 on splice when unsubscribing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.0.1
+
+- Fixed bug where unsubscribing a listener made listeners ahead be also removed.
+
 ### 4.0.0
 
 - Separating `Provider` and `connect` from `createStore`. With this we'll be able to build for different frameworks:

--- a/__tests__/createStore.spec.tsx
+++ b/__tests__/createStore.spec.tsx
@@ -37,9 +37,14 @@ describe("redux-zero", () => {
     store.setState({ a: "key" })
     expect(listener).toBeCalledWith({ a: "key" })
 
+    const otherListener = jest.fn()
+    store.subscribe(otherListener)
+    listener.mockReset()
+
     unsubscribe(listener)
     store.setState({ a: "key" })
-    expect(listener).not.toBeCalledWith()
+    expect(listener).not.toBeCalled()
+    expect(otherListener).toBeCalledWith({ a: "key" })
   })
 
   test("Provider - connect", () => {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.0.0",
+  "version": "4.0.1",
   "description": "",
   "main": "dist/redux-zero.js",
   "typings": "dist/index.d.ts",

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -12,7 +12,7 @@ export default function createStore(state = {}) {
     subscribe(f) {
       listeners.push(f)
       return () => {
-        listeners.splice(listeners.indexOf(f))
+        listeners.splice(listeners.indexOf(f), 1)
       }
     },
     getState() {


### PR DESCRIPTION
Small fix so when unsubscribing the splice doesn't remove the rest of the listeners ahead of the one removing. Also added a small test for that.