### PR TITLE
Let mapToProps optional

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 4.2.1
+
+- Let `mapToProps` function optional
+
+If you don't pass `mapToProps` function to `connect` HOC or `Connect` component, it will inject all state as props at the connected component.
+
+```javascript
+const store = createStore({ message: 'Hey' })
+
+const App = connect()(
+  ({ message }) => (
+    <h1>{message}</h1>
+  )
+)
+```
+
 ### 4.2.0
 
 - Binding actions instead of coupling them to the store.

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.0.0",
+  "version": "4.2.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.2.0",
+  "version": "4.2.1",
   "description": "",
   "main": "dist/redux-zero.js",
   "typings": "dist/index.d.ts",

--- a/src/react/components/connect.spec.tsx
+++ b/src/react/components/connect.spec.tsx
@@ -171,6 +171,21 @@ describe("redux-zero - react bindings", () => {
         "<div>parent bye <span>child bye</span></div>"
       )
     })
+
+    it("should connect return all state when mapToProps is not passed", () => {
+      store.setState({ message: 'Hey!' })
+      const Comp = ({ message }) => <h1>{message}</h1>
+      const ConnectedComp = connect()(Comp)
+
+      const App = () => (
+        <Provider store={store}>
+          <ConnectedComp />
+        </Provider>
+      )
+
+      const wrapper = mount(<App />)
+      expect(wrapper.html()).toBe("<h1>Hey!</h1>")
+    })
   })
 
   describe("Connect component", () => {

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -20,7 +20,7 @@ export class Connect extends React.Component<any> {
   getProps() {
     const { mapToProps } = this.props
     const state = (this.context.store && this.context.store.getState()) || {}
-    return mapToProps(state, this.props)
+    return mapToProps ? mapToProps(state, this.props) : state
   }
   getActions() {
     const { actions } = this.props


### PR DESCRIPTION
This PR add a new funcionality to `connect` HOC, to return all state as props when mapToProps function is not passed.