### PR TITLE
Use explicit setState on example

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,8 +77,16 @@ Then, create your actions. This is where you change the state from your store:
 ```js
 /* actions.js */
 export const actions = store => ({
-  increment: state => ({ count: state.count + 1 }),
-  decrement: state => ({ count: state.count - 1 })
+  increment: state => {
+    store.setState({
+      count: state.count + 1
+    });
+  },
+  decrement: state => {
+    store.setState({
+      count: state.count - 1
+    });
+  }
 })
 ```
 


### PR DESCRIPTION
Use explicit way to setState in the example, that way is more familiar for devs coming from react-redux. Using async example is better because most of the apps have async setState and explicating that into the readme avoid questions