### PR TITLE
Add action argument example in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -82,7 +82,8 @@ Then, create your actions. This is where you change the state from your store:
 /* actions.js */
 const actions = store => ({
   increment: state => ({ count: state.count + 1 }),
-  decrement: state => ({ count: state.count - 1 })
+  decrement: state => ({ count: state.count - 1 }),
+  incrementBy: (state, amount) => ({ count: state.count + amount }),
 });
 
 export default actions;
@@ -101,12 +102,13 @@ import actions from "./actions";
 
 const mapToProps = ({ count }) => ({ count });
 
-export default connect(mapToProps, actions)(({ count, increment, decrement }) => (
+export default connect(mapToProps, actions)(({ count, increment, decrement, incrementBy }) => (
   <div>
     <h1>{count}</h1>
     <div>
       <button onClick={decrement}>decrement</button>
       <button onClick={increment}>increment</button>
+      <button onClick={() => incrementBy(10)}>increment 10</button>
     </div>
   </div>
 ));

--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Then, create your actions. This is where you change the state from your store:
 const actions = store => ({
   increment: state => ({ count: state.count + 1 }),
   decrement: state => ({ count: state.count - 1 }),
-  incrementBy: (state, amount) => ({ count: state.count + amount }),
+  incrementBy: (state, amount) => ({ count: state.count + amount })
 });
 
 export default actions;


### PR DESCRIPTION
*Fix https://github.com/concretesolutions/redux-zero/issues/66*

I've added a simple example using arguments in action (using `incrementBy(amount)` example)

I don't think if it's elegant, or if it's the better way, but I think it works to solve #66 problem.
If you have some suggestion, would be great to improve this PR!