### PR TITLE
Fix typings, unsubscribe isn't used

### DIFF
--- a/src/interfaces/Store.ts
+++ b/src/interfaces/Store.ts
@@ -1,6 +1,5 @@
 export default interface Store {
   setState: Function
   subscribe: Function
-  unsubscribe: Function
   getState: Function
 }


### PR DESCRIPTION
Using redux-zero along with TypeScript gives an error when `<Provider store={store}><Whatever/></Provider>`
```
Type '{ store: { setState(update: any): void; subscribe(f: any): () => void; getState(): {}; }; }' is not assignable to type 'Props & ComponentProps<Provider>'. Type '{ store: { setState(update: any): void; subscribe(f: any): () => void; getState(): {}; }; }' is not assignable to type 'Props'. Types of property 'store' are incompatible. Type '{ setState(update: any): void; subscribe(f: any): () => void; getState(): {}; }' is not assignable to type 'Store'. Property 'unsubscribe' is missing in type '{ setState(update: any): void; subscribe(f: any): () => void; getState(): {}; }'.
```
CreateStore signature doesn't give any `unsubscribe` method, os isn't compatible.