### PR TITLE
Fix typings, remove unsubscribe from Store

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,15 @@
 # Changelog
 
+### 4.4.2
+
+- Fix typings, remove unsubscribe from Store interface since isn't used
+
+[info] Using redux-zero along with TypeScript gives an error when implementing:
+`<Provider store={store}><Whatever/></Provider>` due to the actual store object
+and the expected attribute differ.
+
+- Added Store interface as signature for createStore function.
+
 ### 4.4.1
 
 - Fixes Svelte connect function date object change detection

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.4.1",
+  "version": "4.4.2",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/interfaces/Store.ts
+++ b/src/interfaces/Store.ts
@@ -1,6 +1,5 @@
 export default interface Store {
   setState: Function
   subscribe: Function
-  unsubscribe: Function
   getState: Function
 }

--- a/src/store/createStore.ts
+++ b/src/store/createStore.ts
@@ -1,4 +1,6 @@
-export default function createStore(state = {}) {
+import Store from "../interfaces/Store"
+
+export default function createStore(state = {}): Store {
   const listeners = []
   return {
     setState(update) {


### PR DESCRIPTION
Hi again, thanks!

This repo is awesome :)

----
Using redux-zero along with TypeScript gives an error when `<Provider store={store}><Whatever/></Provider>`
```
Type '{ store: { setState(update: any): void; subscribe(f: any): () => void; getState(): {}; }; }' is not assignable to type 'Props & ComponentProps<Provider>'. Type '{ store: { setState(update: any): void; subscribe(f: any): () => void; getState(): {}; }; }' is not assignable to type 'Props'. Types of property 'store' are incompatible. Type '{ setState(update: any): void; subscribe(f: any): () => void; getState(): {}; }' is not assignable to type 'Store'. Property 'unsubscribe' is missing in type '{ setState(update: any): void; subscribe(f: any): () => void; getState(): {}; }'.
```
CreateStore signature doesn't give any `unsubscribe` method, os isn't compatible.