### PR TITLE
tests to be runned after build, tests should import dist

### DIFF
--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "format": "prettier --write --no-semi \"src/**/*.ts\" \"src/**/*.tsx\"",
     "check": "npm run compile && npm run lint && npm run test",
     "clean": "rimraf dist coverage",
-    "prebuild": "npm run format && npm run check && npm run clean",
+    "postbuild": "npm run format && npm run check && npm run clean",
     "build:umd": "cross-env NODE_ENV=umd rollup --config",
     "build:cjs": "cross-env NODE_ENV=cjs rollup --config",
     "build": "npm run build:umd && npm run build:cjs",

--- a/src/preact/components/Connect.spec.tsx
+++ b/src/preact/components/Connect.spec.tsx
@@ -1,8 +1,15 @@
+declare const describe: any
+declare const beforeEach: any
+declare const jest: any
+declare const Promise: any
+declare const it: any
+declare const expect: any
+
 import { h } from "preact"
 import { deep } from "preact-render-spy"
 
-import createStore from "../.."
-import { Provider, Connect } from ".."
+import createStore from "../../../dist/index"
+import { Connect, Provider } from "../../../preact"
 
 describe("redux-zero - preact bindings", () => {
   const listener = jest.fn()
@@ -144,11 +151,11 @@ describe("redux-zero - preact bindings", () => {
 
       const mapToProps = ({ message }) => ({ message })
 
-      const ConnectedComp = ({ children }) => (
+      const ConnectedComp = props => (
         <Connect mapToProps={mapToProps}>
           {({ message }) => (
             <div>
-              parent {message} {children}
+              parent {message} {props.children}
             </div>
           )}
         </Connect>

--- a/src/store/createStore.spec.ts
+++ b/src/store/createStore.spec.ts
@@ -1,4 +1,12 @@
-import createStore from "./createStore"
+declare const describe: any
+declare const beforeEach: any
+declare const jest: any
+declare const Promise: any
+declare const it: any
+declare const expect: any
+declare const test: any
+
+import createStore from "../../dist/index"
 
 describe("redux-zero - the store", () => {
   const listener = jest.fn()


### PR DESCRIPTION
This doesn't fix any bug, isn't related with https://github.com/concretesolutions/redux-zero/issues/71 which is very weird..

I thing this is the proper way to perform the testing. 

Brief, **I only changed Preact related tests**, to be runned **after** build has bundled all files, and then use those bundles to run the tests. 

Usually _acceptance tests_ are runned against the ultimate result of the build, since there are no such tests I think is worth to do in that way.

I need help with some other problems that I would like to address in a separate issue and I would like to discuss about.

Thanks! any comments appreciated.
