### PR TITLE
feat: add connect decorator for Preact projects

### DIFF
--- a/src/preact/components/Connect.tsx
+++ b/src/preact/components/Connect.tsx
@@ -35,3 +35,13 @@ export default class Connect extends Component<any, {}> {
     return children[0]({ store, ...state, ...this.actions })
   }
 }
+
+// !important. `any` signature to avoid TS complains, due to replacement with a HOC
+export function connect(stateToProps: Function, actions = {}): any {
+  return Child => (props) => (
+    <Connect mapToProps={stateToProps} actions={actions}>
+      {mappedProps => <Child {...mappedProps} {...props} />}
+    </Connect>
+  )
+}
+


### PR DESCRIPTION
build is failing due to this error which is solved by removing `@types/react` T.T

```
Error: rpt2: /home/k1r0s/Works/redux-zero/src/preact/components/Connect.tsx (42,5): semantic error TS2605 JSX element type 'Connect' is not a constructor function for JSX elements.
  Types of property 'render' are incompatible.
    Type '({ children }: { children: any; }, state: any, { store }: { store: any; }) => any' is not assignable to type '() => ReactNode'.
src/preact/components/Connect.tsx

```
@matheusml do you have an alternative?

Thanks
