### PR TITLE
Enhanced async actions flow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,21 @@
 # Changelog
 
+### 4.5.0
+
+- Adds Thennable actions. Now we can declare actions as so:
+
+```js
+const mapActions = ({ setState }) => ({
+  getTodos() {
+    setState({ loading: true });
+
+    return client.get("/todos")
+      .then(payload => ({ payload, loading: false }))
+      .catch(error => ({ error, loading: false }))
+  }
+});
+```
+
 ### 4.4.3
 
 - Removing peerDependencies from `package.json`

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.4.3",
+  "version": "4.5.0",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",
@@ -34,20 +34,12 @@
     "url": "https://github.com/concretesolutions/redux-zero"
   },
   "jest": {
-    "moduleFileExtensions": [
-      "ts",
-      "tsx",
-      "js"
-    ],
-    "setupFiles": [
-      "<rootDir>/config/testSetup.js"
-    ],
+    "moduleFileExtensions": ["ts", "tsx", "js"],
+    "setupFiles": ["<rootDir>/config/testSetup.js"],
     "transform": {
       "^.+\\.(ts|tsx)$": "<rootDir>/config/preprocessor.js"
     },
-    "testMatch": [
-      "<rootDir>/src/**/*.spec.(ts|tsx)"
-    ]
+    "testMatch": ["<rootDir>/src/**/*.spec.(ts|tsx)"]
   },
   "devDependencies": {
     "@types/react": "^16.0.9",

--- a/src/preact/components/Connect.spec.tsx
+++ b/src/preact/components/Connect.spec.tsx
@@ -5,12 +5,11 @@ import createStore from "../.."
 import { Provider, Connect } from ".."
 
 describe("redux-zero - preact bindings", () => {
-  const listener = jest.fn()
-  let store, unsubscribe, context
+  let store, listener, context
   beforeEach(() => {
     store = createStore({})
-    listener.mockReset()
-    unsubscribe = store.subscribe(listener)
+    listener = jest.fn()
+    store.subscribe(listener)
   })
 
   describe("Connect component", () => {
@@ -32,10 +31,10 @@ describe("redux-zero - preact bindings", () => {
       )
 
       context = deep(<App />, { depth: Infinity })
-      expect(context.find("h1").text()).toBe("hello")
+      expect(context.output()).toEqual(<h1>hello</h1>)
       store.setState({ message: "bye" })
       context = deep(<App />, { depth: Infinity })
-      expect(context.find("h1").text()).toBe("bye")
+      expect(context.output()).toEqual(<h1>bye</h1>)
     })
 
     it("should provide the actions and subscribe to changes", () => {
@@ -76,8 +75,10 @@ describe("redux-zero - preact bindings", () => {
       const mapToProps = ({ count }) => ({ count })
 
       const actions = ({ getState, setState }) => ({
-        increment: state => {
-          Promise.resolve()
+        increment() {
+          setState({ pending: true })
+
+          return Promise.resolve()
             .then(() => {
               setState({ pending: false, count: getState().count + 1 })
             })
@@ -97,8 +98,6 @@ describe("redux-zero - preact bindings", () => {
 
               done()
             })
-
-          return { pending: true }
         }
       })
 

--- a/src/preact/components/Connect.tsx
+++ b/src/preact/components/Connect.tsx
@@ -1,9 +1,9 @@
-import { h, Component } from "preact"
+import * as preact from "preact"
 
 import shallowEqual from "../../utils/shallowEqual"
 import bindActions from "../../utils/bindActions"
 
-export default class Connect extends Component<any, {}> {
+export default class Connect extends preact.Component<any, {}> {
   unsubscribe
   state = this.getProps()
   actions = this.getActions()
@@ -32,6 +32,6 @@ export default class Connect extends Component<any, {}> {
     }
   }
   render({ children }, state, { store }) {
-    return children[0]({ store, ...state, ...this.actions })
+    return children[0] && children[0]({ store, ...state, ...this.actions })
   }
 }

--- a/src/preact/components/Connect.tsx
+++ b/src/preact/components/Connect.tsx
@@ -1,11 +1,12 @@
-import * as preact from "preact"
+import { Component } from "preact"
 
 import shallowEqual from "../../utils/shallowEqual"
 import bindActions from "../../utils/bindActions"
 
-export default class Connect extends preact.Component<any, {}> {
+export default class Connect extends Component<any, {}> {
   unsubscribe
-  state = { ...this.getProps(), ...this.getActions() }
+  state = this.getProps()
+  actions = this.getActions()
   componentWillMount() {
     this.unsubscribe = this.context.store.subscribe(this.update)
   }
@@ -28,6 +29,6 @@ export default class Connect extends preact.Component<any, {}> {
     }
   }
   render({ children }, state, { store }) {
-    return children[0] && children[0]({ store, ...state })
+    return children[0]({ store, ...state, ...this.actions })
   }
 }

--- a/src/preact/components/Connect.tsx
+++ b/src/preact/components/Connect.tsx
@@ -5,8 +5,7 @@ import bindActions from "../../utils/bindActions"
 
 export default class Connect extends preact.Component<any, {}> {
   unsubscribe
-  state = this.getProps()
-  actions = this.getActions()
+  state = { ...this.getProps(), ...this.getActions() }
   componentWillMount() {
     this.unsubscribe = this.context.store.subscribe(this.update)
   }
@@ -20,10 +19,7 @@ export default class Connect extends preact.Component<any, {}> {
   }
   getActions() {
     const { actions } = this.props
-    return bindActions(
-      typeof actions === "function" ? actions(this.context.store) : actions,
-      this.context.store
-    )
+    return bindActions(actions, this.context.store)
   }
   update = () => {
     const mapped = this.getProps()
@@ -32,6 +28,6 @@ export default class Connect extends preact.Component<any, {}> {
     }
   }
   render({ children }, state, { store }) {
-    return children[0] && children[0]({ store, ...state, ...this.actions })
+    return children[0] && children[0]({ store, ...state })
   }
 }

--- a/src/react/components/connect.spec.tsx
+++ b/src/react/components/connect.spec.tsx
@@ -5,12 +5,11 @@ import createStore from "../.."
 import { Provider, Connect, connect } from ".."
 
 describe("redux-zero - react bindings", () => {
-  const listener = jest.fn()
-  let store, unsubscribe
+  let store, listener
   beforeEach(() => {
     store = createStore({})
-    listener.mockReset()
-    unsubscribe = store.subscribe(listener)
+    listener = jest.fn()
+    store.subscribe(listener)
   })
 
   describe("connect HOC", () => {
@@ -110,8 +109,10 @@ describe("redux-zero - react bindings", () => {
       const mapToProps = ({ count }) => ({ count })
 
       const actions = ({ getState, setState }) => ({
-        increment: state => {
-          Promise.resolve()
+        increment() {
+          setState({ pending: true })
+
+          return Promise.resolve()
             .then(() => {
               setState({ pending: false, count: getState().count + 1 })
             })
@@ -131,8 +132,6 @@ describe("redux-zero - react bindings", () => {
 
               done()
             })
-
-          return { pending: true }
         }
       })
 
@@ -320,8 +319,10 @@ describe("redux-zero - react bindings", () => {
       const mapToProps = ({ count }) => ({ count })
 
       const actions = ({ getState, setState }) => ({
-        increment: state => {
-          Promise.resolve()
+        increment() {
+          setState({ pending: true })
+
+          return Promise.resolve()
             .then(() => {
               setState({ pending: false, count: getState().count + 1 })
             })
@@ -341,8 +342,6 @@ describe("redux-zero - react bindings", () => {
 
               done()
             })
-
-          return { pending: true }
         }
       })
 

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -9,7 +9,8 @@ export class Connect extends React.Component<any> {
     store: propValidation
   }
   unsubscribe
-  state = { ...this.getProps(), ...this.getActions() }
+  state = this.getProps()
+  actions = this.getActions()
   componentWillMount() {
     this.unsubscribe = this.context.store.subscribe(this.update)
   }
@@ -32,7 +33,11 @@ export class Connect extends React.Component<any> {
     }
   }
   render() {
-    return this.props.children({ store: this.context.store, ...this.state })
+    return this.props.children({
+      store: this.context.store,
+      ...this.state,
+      ...this.actions
+    })
   }
 }
 

--- a/src/react/components/connect.tsx
+++ b/src/react/components/connect.tsx
@@ -9,8 +9,7 @@ export class Connect extends React.Component<any> {
     store: propValidation
   }
   unsubscribe
-  state = this.getProps()
-  actions = this.getActions()
+  state = { ...this.getProps(), ...this.getActions() }
   componentWillMount() {
     this.unsubscribe = this.context.store.subscribe(this.update)
   }
@@ -24,10 +23,7 @@ export class Connect extends React.Component<any> {
   }
   getActions() {
     const { actions } = this.props
-    return bindActions(
-      typeof actions === "function" ? actions(this.context.store) : actions,
-      this.context.store
-    )
+    return bindActions(actions, this.context.store)
   }
   update = () => {
     const mapped = this.getProps()
@@ -36,11 +32,7 @@ export class Connect extends React.Component<any> {
     }
   }
   render() {
-    return this.props.children({
-      store: this.context.store,
-      ...this.state,
-      ...this.actions
-    })
+    return this.props.children({ store: this.context.store, ...this.state })
   }
 }
 

--- a/src/svelte/components/connect.ts
+++ b/src/svelte/components/connect.ts
@@ -2,10 +2,7 @@ import getDiff from "../../utils/getDiff"
 import bindActions from "../../utils/bindActions"
 
 export function getActions(store, actions) {
-  return bindActions(
-    typeof actions === "function" ? actions(store) : actions,
-    store
-  )
+  return bindActions(actions, store)
 }
 
 export function connect(component, store, mapToProps) {

--- a/src/utils/bindActions.spec.ts
+++ b/src/utils/bindActions.spec.ts
@@ -1,0 +1,65 @@
+import createStore from "../"
+import bindActions from "./bindActions"
+
+const getActions = ({ setState }) => ({
+  syncAction: ({ count }) => ({ count: count + 1 }),
+  syncActionWithParam: ({ count }, amount) => ({ count: count + amount }),
+  successAsyncAction() {
+    setState({ loading: true })
+
+    return Promise.resolve({ some: "mock data" })
+      .then(payload => ({ payload, loading: false }))
+      .catch(error => ({ error, loading: false }))
+  },
+  failingAsyncAction() {
+    setState({ loading: true })
+
+    return Promise.reject({ message: "I'M ERROR" })
+      .then(payload => ({ payload, loading: false }))
+      .catch(error => ({ error, loading: false }))
+  }
+})
+
+describe("bindActions", () => {
+  let actions, store, listener
+  beforeEach(() => {
+    store = createStore({ count: 0 })
+    listener = jest.fn()
+    store.subscribe(listener)
+    actions = bindActions(getActions(store), store)
+  })
+
+  it("should perform sync actions", () => {
+    actions.syncAction()
+
+    expect(store.getState().count).toBe(1)
+  })
+
+  it("should perform sync actions with params", () => {
+    actions.syncActionWithParam(10)
+
+    expect(store.getState().count).toBe(10)
+  })
+
+  it("should perform an async action", () =>
+    actions.successAsyncAction().then(() => {
+      const [LOADING_STATE, SUCCESS_STATE] = listener.mock.calls.map(
+        ([call]) => call
+      )
+
+      expect(LOADING_STATE.loading).toBe(true)
+      expect(SUCCESS_STATE.payload).toEqual({ some: "mock data" })
+      expect(SUCCESS_STATE.loading).toBe(false)
+    }))
+
+  it("should fail an async action", () =>
+    actions.failingAsyncAction().then(() => {
+      const [LOADING_STATE, FAILING_STATE] = listener.mock.calls.map(
+        ([call]) => call
+      )
+
+      expect(LOADING_STATE.loading).toBe(true)
+      expect(FAILING_STATE.error).toEqual({ message: "I'M ERROR" })
+      expect(FAILING_STATE.loading).toBe(false)
+    }))
+})

--- a/src/utils/bindActions.spec.ts
+++ b/src/utils/bindActions.spec.ts
@@ -11,6 +11,13 @@ const getActions = ({ setState }) => ({
       .then(payload => ({ payload, loading: false }))
       .catch(error => ({ error, loading: false }))
   },
+  asyncActionWithParam(state, id) {
+    setState({ loading: true })
+
+    return Promise.resolve({ some: "mock data", id })
+      .then(payload => ({ payload, loading: false }))
+      .catch(error => ({ error, loading: false }))
+  },
   failingAsyncAction() {
     setState({ loading: true })
 
@@ -26,7 +33,7 @@ describe("bindActions", () => {
     store = createStore({ count: 0 })
     listener = jest.fn()
     store.subscribe(listener)
-    actions = bindActions(getActions(store), store)
+    actions = bindActions(getActions, store)
   })
 
   it("should perform sync actions", () => {
@@ -52,7 +59,18 @@ describe("bindActions", () => {
       expect(SUCCESS_STATE.loading).toBe(false)
     }))
 
-  it("should fail an async action", () =>
+  it("should perform an async action with params", () =>
+    actions.asyncActionWithParam(1).then(() => {
+      const [LOADING_STATE, SUCCESS_STATE] = listener.mock.calls.map(
+        ([call]) => call
+      )
+
+      expect(LOADING_STATE.loading).toBe(true)
+      expect(SUCCESS_STATE.payload).toEqual({ some: "mock data", id: 1 })
+      expect(SUCCESS_STATE.loading).toBe(false)
+    }))
+
+  it("should fail a falling async action", () =>
     actions.failingAsyncAction().then(() => {
       const [LOADING_STATE, FAILING_STATE] = listener.mock.calls.map(
         ([call]) => call

--- a/src/utils/bindActions.ts
+++ b/src/utils/bindActions.ts
@@ -1,4 +1,6 @@
 export default function bindActions(actions, store) {
+  actions = typeof actions === "function" ? actions(store) : actions
+
   let bound = {}
   for (let name in actions) {
     bound[name] = (...args) => {
@@ -9,5 +11,6 @@ export default function bindActions(actions, store) {
       }
     }
   }
+
   return bound
 }

--- a/src/utils/bindActions.ts
+++ b/src/utils/bindActions.ts
@@ -3,7 +3,10 @@ export default function bindActions(actions, store) {
   for (let name in actions) {
     bound[name] = (...args) => {
       let ret = actions[name](store.getState(), ...args)
-      if (ret != null) store.setState(ret)
+      if (ret != null) {
+        if (ret.then) return ret.then(store.setState)
+        store.setState(ret)
+      }
     }
   }
   return bound


### PR DESCRIPTION
Currently redux-zero async actions have the following flow:

```js
const mapActions = ({ setState }) => ({
  getTodos() { 
    client.get("/todos")
      .then(payload => setState({ payload, loading: false }))
      .catch(error => setState({ error, loading: false }));

    return { loading: true }
  }
});
```

While this is a good approach that just works, it is not perfect. The first problem is that it doesn't read top to bottom, so it's not as straightforward  and intuitive as a sync action that is pure and easy to reason about:

```js
const mapActions = store => ({ increment: ({ count }) => ({ count: count + 1 }) })
```

Second problem is that this is very hard code to test, because we have to figure out a way to find when the top promise will resolve.

With this PR I'm proposing we change that flow for something that reads better and has a better testability:

```js
const mapActions = ({ setState }) => ({
  getTodos() {
    setState({ loading: true });
      
    return client.get("/todos")
      .then(payload => ({ payload, loading: false }))
      .catch(error => ({ error, loading: false }))
  }
});
```
In my opinion the approach above is ideal because: first it reads top to bottom, second it resembles a sync action - so we are starting to think about good practices and drawing some boundaries around the lib - and finally it tests better. It can be done roughly as so:

```js
describe("todo actions", () => {
  let actions, store, listener, unsubscribe;
  beforeEach(() => {
    store = createStore();
    actions = getActions(store);
    listener = jest.fn();
    unsubscribe = store.subscribe(listener);
  });

  it("should fetch todos", () => {
    nock("http://someapi.com/")
      .get("/todos")
      .reply(200, { id: 1, title: "test stuff" });

    return actions.getTodos().then(() => {
      const [LOADING_STATE, SUCCESS_STATE] = listener.mock.calls.map(
        ([call]) => call
      );

      expect(LOADING_STATE.loading).toBe(true);
      expect(SUCCESS_STATE.payload).toEqual({ id: 1, title: "test stuff" });
      expect(SUCCESS_STATE.loading).toBe(false);
    });
  });
});
```

**Important: this is not a solved problem yet.** The mapActions function does not bound the actions to the store. We have an internal method that does that (`bindActions`). So at this point we have to figure out a way to solve this problem.

I can see two options: we can expose this `bindActions` (kind of how our Svelte bindings do by exporting `getActions`), which is the proposition I'm prone to. Or create a helper function for tests...