### PR TITLE
fix(middleware): fix a bug which middlewares array will reverse more …

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.8.1
+
+- Fix a bug of middleware
+
 ### 4.8.0
 
 - Add bindActions export

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.8.0",
+  "version": "4.8.1",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/middleware/applyMiddleware.spec.ts
+++ b/src/middleware/applyMiddleware.spec.ts
@@ -4,12 +4,16 @@ import bindActions from "../utils/bindActions"
 
 const getActions = ({ getState }) => ({
   syncAction: ({ count }) => ({ count: count + 1 }),
-  syncActionDouble: ({ count }) => ({ count: count + 2 })
+  syncActionDouble: ({ count }) => ({ count: count + 2 }),
+  syncActionTriple: ({ count }) => ({ count: count + 3 })
 })
 
 const noAction = () => () => () => {}
 const doAnotherAction = store => next => action => {
   return next(getActions(store).syncActionDouble)
+}
+const doTripleAction = store => next => action => {
+  return next(getActions(store).syncActionTriple)
 }
 
 describe("applyMiddleware", () => {
@@ -35,5 +39,17 @@ describe("applyMiddleware", () => {
 
     actions.syncAction()
     expect(store.getState().count).toBe(2)
+  })
+
+  it("should apply middlewares in correct order", () => {
+    const store = createStore(
+      { count: 1 },
+      applyMiddleware(doTripleAction, doAnotherAction)
+    )
+    const actions = bindActions(getActions, store)
+
+    actions.syncAction()
+    actions.syncAction()
+    expect(store.getState().count).toBe(5) // 1 + 2 + 2 not 1 + 2 + 3
   })
 })

--- a/src/middleware/applyMiddleware.ts
+++ b/src/middleware/applyMiddleware.ts
@@ -5,13 +5,13 @@ const finalMiddleware = (store: Store, args) => (action: Function) =>
   set(store, action(store.getState(), ...args))
 
 export default function applyMiddleware(...middlewares) {
+  middlewares = middlewares.reverse() // just reverse once
   return (store: Store, action: Function, args) => {
     if (middlewares.length < 1) {
       return set(store, action(store.getState(), ...args))
     }
 
     const chain = middlewares
-      .reverse()
       .map(middleware => middleware(store))
       .reduce(
         (next, middleware) => middleware(next),

--- a/src/middleware/applyMiddleware.ts
+++ b/src/middleware/applyMiddleware.ts
@@ -5,7 +5,7 @@ const finalMiddleware = (store: Store, args) => (action: Function) =>
   set(store, action(store.getState(), ...args))
 
 export default function applyMiddleware(...middlewares) {
-  middlewares = middlewares.reverse() // just reverse once
+  middlewares.reverse()
   return (store: Store, action: Function, args) => {
     if (middlewares.length < 1) {
       return set(store, action(store.getState(), ...args))


### PR DESCRIPTION
if reverse middlewares array every time,then
```
const middleware1 = store => next => action => {console.log(1);return next(action)}
const middleware2 = store => next => action => {console.log(2);return next(action)}
const middleware3 = store => next => action => {console.log(3);return next(action)}

const store = createStore({count:1}, applyMiddlewar(middleware1, middleware2, middleware3))

actions.increment() // 1,2,3
actions.increment() // 3,2,1
actions.increment() // 1,2,3
```