### PR TITLE
Disable generation of source maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,12 @@
 # Changelog
-### 4.9.0
-
-- Add DevTools middleware
 
 ### 4.9.1
 
 - Disable generation of source maps
+
+### 4.9.0
+
+- Add DevTools middleware
 
 ### 4.8.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.9.1
+
+- Disable generation of source maps
+
 ### 4.8.1
 
 - Fix a bug of middleware

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.8.1",
+  "version": "4.9.1",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/rollup.config.js
+++ b/rollup.config.js
@@ -43,7 +43,7 @@ function getConfig(input, file) {
   const conf = {
     input,
     name: 'redux-zero',
-    sourcemap: true,
+    sourcemap: false,
     external: getExternals(file),
     output: {
       file: getFileName(file),

--- a/src/preact/tsconfig.json
+++ b/src/preact/tsconfig.json
@@ -2,7 +2,6 @@
   "compilerOptions": {
     "jsx": "react",
     "jsxFactory": "h",
-    "inlineSources": true,
     "module": "commonjs",
     "declaration": true,
     "noImplicitAny": false,

--- a/src/preact/tsconfig.json
+++ b/src/preact/tsconfig.json
@@ -8,7 +8,7 @@
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,
     "removeComments": false,
-    "sourceMap": true,
+    "sourceMap": false,
     "target": "ES5",
     "outDir": "./dist"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -7,7 +7,7 @@
     "noImplicitAny": false,
     "suppressImplicitAnyIndexErrors": true,
     "removeComments": false,
-    "sourceMap": true,
+    "sourceMap": false,
     "target": "ES5",
     "outDir": "./dist"
   },

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,6 @@
 {
   "compilerOptions": {
     "jsx": "react",
-    "inlineSources": true,
     "module": "commonjs",
     "declaration": true,
     "noImplicitAny": false,


### PR DESCRIPTION
Resulted js file contains a reference to a source maps file. When a bundler appends the content of the file, it also includes a reference to source maps, but a browser then complains that source maps can't be found. Therefore, don't generate source maps for `dist` files.