### PR TITLE
Relay action args to middleware and devtools

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+### 4.12.0
+
+- Pass action `args` to middleware and devtools
+
 ### 4.11.0
 
 - Add `combineActions` function

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "redux-zero",
-  "version": "4.11.0",
+  "version": "4.12.0",
   "description": "",
   "main": "dist/redux-zero.js",
   "types": "index.d.ts",

--- a/src/devtools/devtoolsMiddleware.spec.ts
+++ b/src/devtools/devtoolsMiddleware.spec.ts
@@ -10,9 +10,12 @@ import {
 
 const increment = ({ count }) => ({ count: count + 1 });
 const decrement = ({ count }) => ({ count: count - 1 });
+const incrementBy = ({ count }, amount) => ({ count: count + amount });
+
 const getActions = () => ({
   increment,
-  decrement
+  decrement,
+  incrementBy
 });
 
 const getAsyncActions = ({ setState }) => ({
@@ -117,6 +120,27 @@ describe("sendActions", () => {
 
     expect(store.getState().count).toBe(2);
     expect(sendCalled).toBe(true);
+    expect(subscribeCalled).toBe(true);
+  });
+
+  it("should send action args to store", () => {
+    const actions = bindActions(getActions, store);
+    let sendCalled = false;
+    let subscribeCalled = false;
+    let sentAction = null;
+    devTools.instance = {
+      send: (action, state) => {
+        sentAction = action;
+        sendCalled = true;
+      },
+      subscribe: () => (subscribeCalled = true)
+    };
+    actions.incrementBy(5);
+
+    expect(store.getState().count).toBe(6);
+    expect(sendCalled).toBe(true);
+    expect(sentAction.type).toBe("incrementBy");
+    expect(sentAction.args).toEqual([5]);
     expect(subscribeCalled).toBe(true);
   });
 

--- a/src/devtools/devtoolsMiddleware.ts
+++ b/src/devtools/devtoolsMiddleware.ts
@@ -56,16 +56,17 @@ function subscribe(store, middleware) {
   }
 }
 
-const devtoolsMiddleware = store => next => action => {
+const devtoolsMiddleware = store => (next, args) => action => {
   let result = next(action);
   subscribe(store, devtoolsMiddleware);
   getOrAddAction(action, () => next(action));
+  const reduxAction = { type: action.name, args: args };
   if (result && result.then) {
     return result.then(() =>
-      devTools.instance.send(action.name, store.getState())
+      devTools.instance.send(reduxAction, store.getState())
     );
   }
-  devTools.instance.send(action.name, store.getState());
+  devTools.instance.send(reduxAction, store.getState());
   return result;
 };
 

--- a/src/middleware/applyMiddleware.ts
+++ b/src/middleware/applyMiddleware.ts
@@ -14,7 +14,7 @@ export default function applyMiddleware(...middlewares) {
     const chain = middlewares
       .map(middleware => middleware(store))
       .reduce(
-        (next, middleware) => middleware(next),
+        (next, middleware) => middleware(next, args),
         finalMiddleware(store, args)
       );
 


### PR DESCRIPTION
Currently `devtoolsMiddleware` only provides the name of the action invoked and the resulting state.  It does not provide any payloads that may have been sent as arguments to the action.  Similarly, `applyMiddleware` does not currently forward args to middleware.

Summary of changes:

1. Make `applyMiddleware` pass `args` to each middleware as a 2nd argument after `next`.
2. Make `devtoolsMiddleware` invoke the `send` to redux devtools with a conforming action object having the structure `{ type: action.name, args: args}`, where `args` is the array of arguments that were passed into the action invocation.
3. Add test "should send args to store" to `devtoolsMiddleware.spec`, which invokes an action taking arguments (`incrementBy`) and confirms that it sends an action with the correct `type` and `args` array.
